### PR TITLE
Update Db_timestamp.php

### DIFF
--- a/libraries/Db_timestamp.php
+++ b/libraries/Db_timestamp.php
@@ -137,9 +137,9 @@ class Db_timestamp
      * 
      * @return bool
      */
-    public function delete($table = '', $where = NULL, $data = NULL)
+    public function delete($table = '', $where = NULL)
     {
-        $data += array(
+        $data = array(
             $this->delete . $this->_verify_suffix($table)  => date($this->format_time, time()),
         );
 


### PR DESCRIPTION
I remove the variable $data from the funciton delete, because I don't really see a reason why it exists. A DELETE function just delete a row from the table according to the column and the field passed, nothing more, nothing less.
The other reason is that when you did not pass a value for the $data variable, it would cause an error, so you were required to pass an empty array as a parameter. 